### PR TITLE
fix : Make OIDC logout working when end_session_endpoint is present in configuration - MEED-10192 - Meeds-io/meeds#4024

### DIFF
--- a/docs/administration/oauth-integration.md
+++ b/docs/administration/oauth-integration.md
@@ -211,6 +211,13 @@ To configure the lifetime of this cookie, you can set this property :
    exo.oauth.openid.cookie.lifetime=86400
 ```
 
+When using OpenId, when a user logs out, you can decide if you want to propagate the logout to the IDP. If the well-known configuration file contains an url for `end_session_endpoint`, eXo Platform can call this url to logout the user from the IDP too.
+By default, the logout propagation is disabled. To enable it, you can set this property in exo.properties :
+
+```properties 
+   exo.oauth.openid.propagate.logout=true
+```
+
 Restart eXo Platform server. Your users should be able to register or log in with their social network accounts.
 
 ## On-the-fly registration


### PR DESCRIPTION
Before this fix, when using OIDC, some IDP provide a endsession_endpoint url, to make a logout on the IDP after being loggued out from the SP, and eXo do not use this url This commit ensure to send the user in this url if existing and if property exo.oauth.openid.propagate.logout is set to true To achieve this modification, this commit create a new handler in the platform to manage the logout : LogoutHandler on /portal/logout. The old logout code (UIPortal.LogoutActionListener) is removed

Resolves Meeds-io/meeds#4024